### PR TITLE
Don't overwrite sudoers config when upgrading

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -39,10 +39,6 @@ yunohost service add "$app" --description="OliveTin service" --log="/var/log/$ap
 
 ynh_use_logrotate
 
-ynh_add_config --template="sudoers.txt" --destination="/etc/sudoers.d/$app"
-chmod 640 "/etc/sudoers.d/$app"
-chown root:root "/etc/sudoers.d/$app"
-
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================


### PR DESCRIPTION
## Problem

- As raised in #3, I think we shouldn't overwrite the dedicated sudoers file when upgrading; it means coming back from your custom file to an example one

## Solution

- Don't overwrite dedicated sudoers file

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
